### PR TITLE
Change Moonset and Moonrise type to string

### DIFF
--- a/src/WeatherAPI.NET/Entities/AstroEntity.cs
+++ b/src/WeatherAPI.NET/Entities/AstroEntity.cs
@@ -22,13 +22,13 @@ namespace WeatherAPI.NET.Entities
         /// Gets or sets the moonrise time.
         /// </summary>
         [JsonProperty("moonrise")]
-        public DateTime Moonrise { get; set; }
+        public string Moonrise { get; set; }
 
         /// <summary>
         /// Gets or sets the moonset time.
         /// </summary>
         [JsonProperty("moonset")]
-        public DateTime Moonset { get; set; }
+        public string Moonset { get; set; }
 
         /// <summary>
         /// Gets or sets the sunrise time.


### PR DESCRIPTION
Receiving string "No moonset" from the API results in serialization error:

_Could not convert string to DateTime: No moonset. Path 'forecast.forecastday[0].astro.moonset_

This PR fixes that by changing the type from DateTime to string.