### PR TITLE
Fix serialization error

### DIFF
--- a/src/WeatherAPI.NET.Extensions.NodaTime/Extensions.cs
+++ b/src/WeatherAPI.NET.Extensions.NodaTime/Extensions.cs
@@ -40,12 +40,14 @@ namespace WeatherAPI.NET.Extensions.NodaTime
         /// <param name="inZoneLeniantly">Whether to use leniant or strict zone conversion.</param>
         public static ZonedDateTime GetZonedMoonrise(this AstronomyResponseEntity astronomyResponseEntity, bool inZoneLeniantly = true)
         {
+            var MoonriseTime = Convert.ToDateTime(astronomyResponseEntity.Astronomy.Astro.Moonrise);
+
             return GetZonedDateTime(astronomyResponseEntity.Location.LocalTime.Year,
                 astronomyResponseEntity.Location.LocalTime.Month,
                 astronomyResponseEntity.Location.LocalTime.Day,
-                astronomyResponseEntity.Astronomy.Astro.Moonrise.Hour,
-                astronomyResponseEntity.Astronomy.Astro.Moonrise.Minute,
-                astronomyResponseEntity.Astronomy.Astro.Moonrise.Second,
+                MoonriseTime.Hour,
+                MoonriseTime.Minute,
+                MoonriseTime.Second,
                 astronomyResponseEntity.Location.TimeZoneID,
                 inZoneLeniantly);
         }

--- a/src/WeatherAPI.NET/Entities/AstroEntity.cs
+++ b/src/WeatherAPI.NET/Entities/AstroEntity.cs
@@ -22,25 +22,34 @@ namespace WeatherAPI.NET.Entities
         /// Gets or sets the moonrise time.
         /// </summary>
         [JsonProperty("moonrise")]
-        public DateTime Moonrise { get; set; }
+        public string Moonrise { get; set; }
 
         /// <summary>
         /// Gets or sets the moonset time.
         /// </summary>
         [JsonProperty("moonset")]
-        public DateTime Moonset { get; set; }
+        public string Moonset { get; set; }
 
         /// <summary>
         /// Gets or sets the sunrise time.
         /// </summary>
         [JsonProperty("sunrise")]
-        public DateTime Sunrise { get; set; }
+        public string Sunrise { get; set; }
 
         /// <summary>
         /// Gets or sets the sunset time.
         /// </summary>
         [JsonProperty("sunset")]
-        public DateTime Sunset { get; set; }
+        public string Sunset { get; set; }
+
+        public DateTime MoonriseTime => Convert.ToDateTime(Moonrise);
+
+        public DateTime MoonsetTime => Convert.ToDateTime(Moonset);
+
+        public DateTime SunriseTime => Convert.ToDateTime(Sunrise);
+
+        public DateTime SunsetTime => Convert.ToDateTime(Sunset);
+
         #endregion
     }
 }

--- a/src/WeatherAPI.NET/WeatherAPI.NET.csproj
+++ b/src/WeatherAPI.NET/WeatherAPI.NET.csproj
@@ -24,7 +24,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <None Include="C:\Users\Lewis\Downloads\icon.png">
+    <None Include="icon.png">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>


### PR DESCRIPTION
Receiving string "No moonset" from the API results in serialization error:

_Could not convert string to DateTime: No moonset. Path 'forecast.forecastday[0].astro.moonset_

**Changes:**

1. Fix the above issue by changing the type from DateTime to string.
2. Changes project settings file to use the icon located in the project directory.